### PR TITLE
feat(mCIDE): draft expanded_patient_attributes vocabulary

### DIFF
--- a/mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_categories.csv
+++ b/mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_categories.csv
@@ -1,0 +1,11 @@
+attribute_category,description,attribute_name_examples,attribute_group
+code_status,Resuscitation preference documented in orders,"Full Code, DNR, DNI, DNR/DNI, Comfort Care",Clinical Core
+weight,Patient weight in kilograms,"Weight (kg), Admission Weight, Daily Weight",Clinical Core
+bmi,Body mass index category,"BMI, Body Mass Index",Clinical Core
+pregnancy_status,Pregnancy status if applicable,"Pregnant, Not Pregnant, Unknown",Clinical Core
+isolation_precautions,Active isolation orders,"Contact, Droplet, Airborne, None",Clinical Core
+functional_status,Baseline functional capacity at admission,"Independent, Partially Dependent, Fully Dependent",Clinical Core
+smoking_status,Tobacco use history,"Current Smoker, Former Smoker, Never Smoker",Social
+alcohol_use,Alcohol consumption pattern,"None, Social, Heavy, Unknown",Social
+substance_use,Non-alcohol substance use history,"Active, History of, None, Unknown",Social
+insurance_payer_type,Primary insurance category,"Medicare, Medicaid, Commercial, Self-Pay",Social

--- a/mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_value_categories.csv
+++ b/mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_value_categories.csv
@@ -1,0 +1,40 @@
+attribute_category,attribute_value_category,description
+code_status,Full Code,All resuscitative measures including CPR and intubation
+code_status,DNR,Do not resuscitate — no chest compressions
+code_status,DNI,Do not intubate — no endotracheal intubation
+code_status,DNR/DNI,Do not resuscitate or intubate
+code_status,Comfort Care,Comfort measures only — no life-prolonging interventions
+weight,kg,Weight recorded in kilograms
+bmi,Underweight,BMI less than 18.5
+bmi,Normal,BMI 18.5 to 24.9
+bmi,Overweight,BMI 25.0 to 29.9
+bmi,Obese,BMI 30.0 or greater
+pregnancy_status,Pregnant,Currently pregnant
+pregnancy_status,Not Pregnant,Not currently pregnant
+pregnancy_status,Unknown,Pregnancy status not documented or not applicable
+isolation_precautions,Contact,Contact isolation precautions
+isolation_precautions,Droplet,Droplet isolation precautions
+isolation_precautions,Airborne,Airborne isolation precautions
+isolation_precautions,Enhanced Contact,Enhanced barrier contact precautions (e.g. MDRO)
+isolation_precautions,None,No active isolation precautions
+functional_status,Independent,No assistance needed for activities of daily living
+functional_status,Partially Dependent,Requires some assistance with ADLs
+functional_status,Fully Dependent,Requires full assistance with ADLs
+functional_status,Unknown,Functional status not documented
+smoking_status,Current,Active tobacco use at time of admission
+smoking_status,Former,Previously used tobacco but quit
+smoking_status,Never,No history of tobacco use
+smoking_status,Unknown,Smoking status not documented
+alcohol_use,None,Denies alcohol use
+alcohol_use,Social,Occasional or moderate alcohol use
+alcohol_use,Heavy,Heavy or problematic alcohol use
+alcohol_use,Unknown,Alcohol use not documented
+substance_use,Active,Current non-alcohol substance use
+substance_use,History of,Past substance use no longer active
+substance_use,None,Denies substance use
+substance_use,Unknown,Substance use not documented
+insurance_payer_type,Medicare,Federal Medicare coverage
+insurance_payer_type,Medicaid,State Medicaid coverage
+insurance_payer_type,Commercial,Private or employer-sponsored insurance
+insurance_payer_type,Self-Pay,No insurance — patient is financially responsible
+insurance_payer_type,Other,VA benefits or other government programs


### PR DESCRIPTION
## Summary

Draft initial vocabulary for the `expanded_patient_attributes` table ([issue #211](https://github.com/Common-Longitudinal-ICU-data-Format/CLIF/issues/211)).

- **10 attribute categories**: 6 clinical core (code status, weight, BMI, pregnancy status, isolation precautions, functional status) + 4 social determinants (smoking, alcohol, substance use, insurance/payer type)
- **Permissible `attribute_value_category` responses** for each category — EHR-derivable and clinically meaningful
- Follows existing mCIDE CSV format conventions (`attribute_category`, `description`, `attribute_name_examples`, `attribute_group`)

## Intent

This is a **conversation starter for POCs**, not a final spec. We'd appreciate feedback on:

- Missing categories that sites commonly capture in their EHRs
- Value categories that don't map cleanly to your site's data
- Boundary questions with the existing `patient_assessments` table (e.g., functional status scores vs. baseline functional status)

## Files Added

- `mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_categories.csv` — 10 categories with descriptions, name examples, and groupings
- `mCIDE/expanded_patient_attributes/clif_expanded_patient_attribute_value_categories.csv` — permissible values per category (3-5 values each)

Partially addresses #211 (vocabulary only — table implementation is a separate step).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)